### PR TITLE
use devtools.adb.debug to enable logs

### DIFF
--- a/adb.js
+++ b/adb.js
@@ -45,7 +45,11 @@ function createTCPSocket() {
 }
 
 function debug(aStr) {
-  console.log("adb: " + aStr);
+  try {
+    if (Services.prefs.getBoolPref("extensions.adbhelper@mozilla.org.debug")) {
+      console.log("adb: " + aStr);
+    }
+  } catch(e) { }
 }
 
 let ready = false;


### PR DESCRIPTION
These logs are polluting the browser console. Even if the user doesn't use WebIDE (you only need to start WebIDE once to get the addon installed).
