### PR TITLE
Bug 1210824 - Repair pull / push for Gecko 43+. r=ochameau

### DIFF
--- a/adb-client.js
+++ b/adb-client.js
@@ -19,13 +19,21 @@ let { TextEncoder, TextDecoder } = Cu.import("resource://gre/modules/Services.js
 const USE_PACKET_BUFFER =
   Services.vc.compare(Services.appinfo.platformVersion, "43.0a1") >= 0;
 
+const OKAY = 0x59414b4f;
+const FAIL = 0x4c494146;
+
 let _sockets = [ ];
+
+// Return buffer, which differs between Gecko versions
+function getBuffer(aPacket) {
+  return USE_PACKET_BUFFER ? aPacket.buffer : aPacket;
+}
 
 // @param aPacket         The packet to get the length from.
 // @param aIgnoreResponse True if this packet has no OKAY/FAIL.
 // @return                A js object { length:...; data:... }
 function unpackPacket(aPacket, aIgnoreResponse) {
-  let buffer = USE_PACKET_BUFFER ? aPacket.buffer : aPacket;
+  let buffer = getBuffer(aPacket);
   console.debug("Len buffer: " + buffer.byteLength);
   if (buffer.byteLength === 4 && !aIgnoreResponse) {
     console.debug("Packet empty");
@@ -38,18 +46,16 @@ function unpackPacket(aPacket, aIgnoreResponse) {
   return { length: length, data: decoder.decode(text) };
 }
 
-// Checks if the response is OKAY or FAIL.
-// @return true for OKAY, false for FAIL.
-function checkResponse(aPacket) {
-  const OKAY = 0x59414b4f; // OKAY
-  const FAIL = 0x4c494146; // FAIL
-  let buffer = USE_PACKET_BUFFER ? aPacket.buffer : aPacket;
+// Checks if the response is expected (defaults to OKAY).
+// @return true if response equals expected.
+function checkResponse(aPacket, aExpected = OKAY) {
+  let buffer = getBuffer(aPacket);
   let view = new Uint32Array(buffer, 0 , 1);
   if (view[0] == FAIL) {
     console.debug("Response: FAIL");
   }
   console.debug("view[0] = " + view[0]);
-  return view[0] == OKAY;
+  return view[0] == aExpected;
 }
 
 // @param aCommand A protocol-level command as described in
@@ -78,6 +84,7 @@ function connect() {
 }
 
 let client = {
+  getBuffer: getBuffer,
   unpackPacket: unpackPacket,
   checkResponse: checkResponse,
   createRequest: createRequest,
@@ -86,4 +93,3 @@ let client = {
 };
 
 module.exports = client;
-

--- a/adb.js
+++ b/adb.js
@@ -85,7 +85,7 @@ const ADB = {
   // the tcp socket preference to |true|
   start: function adb_start() {
     let deferred = promise.defer();
-    
+
     let onSuccessfulStart = (function onSuccessfulStart() {
       Services.obs.notifyObservers(null, "adb-ready", null);
       this.ready = true;
@@ -546,7 +546,7 @@ const ADB = {
             shutdown();
             return;
           }
-          view = new Uint32Array(aData);
+          view = new Uint32Array(client.getBuffer(aData));
           // view contains 4 elements of 32 bit;
           // the first element is hex "STAT"
           // the second one is file mode
@@ -577,7 +577,7 @@ const ADB = {
           // Handle every single socket package here.
           // Note: One socket package maybe contain many chunks, and often
           // partial chunk at the end.
-          pkgData = new Uint8Array(aData);
+          pkgData = new Uint8Array(client.getBuffer(aData));
 
           // Handle all data in a single socket package.
           while(pkgData.length > 0) {
@@ -890,7 +890,7 @@ const ADB = {
         case "decode-shell":
           if (aData) {
             let decoder = new TextDecoder();
-            let text = new Uint8Array(aData);
+            let text = new Uint8Array(client.getBuffer(aData));
             stdout += decoder.decode(text)
           }
         break;


### PR DESCRIPTION
pull / push uses multiple `TypedArray` view sizes and needs to get the buffer correctly for things to work as expected.