### PR TITLE
Bug 1201392 - Update ADB helper for new paths after bug 1203159. 

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -68,10 +68,19 @@ function startup(data, reason) {
   // In Firefox 44 and later, many DevTools modules were relocated.
   // See https://bugzil.la/912121
   let ConsoleAPI;
-  try {
-    ({ ConsoleAPI } = Cu.import("resource://gre/modules/devtools/shared/Console.jsm"));
-  } catch (e) {
-    ({ ConsoleAPI } = Cu.import("resource://gre/modules/devtools/Console.jsm"));
+  let consolePaths = [
+    "resource://gre/modules/Console.jsm",
+    "resource://gre/modules/devtools/shared/Console.jsm",
+    "resource://gre/modules/devtools/Console.jsm",
+  ];
+  for (let path of consolePaths) {
+    try {
+      ({ ConsoleAPI } = Cu.import(path));
+      // We loaded a path successfully
+      break;
+    } catch (e) {
+      // We'll try the next path
+    }
   }
 
   let _console = new ConsoleAPI();

--- a/devtools-import.js
+++ b/devtools-import.js
@@ -6,16 +6,25 @@ const { Cu } = require("chrome");
 // See https://bugzil.la/912121
 const PATH_RENAMES = [
   {
-    regex: /^resource:\/\/\/modules\/devtools\/client\/framework\//,
-    replacement: "resource:///modules/devtools/"
+    regex: /^resource:\/\/devtools\/client\/framework\//,
+    replacements: [
+      "resource:///modules/devtools/client/framework/",
+      "resource:///modules/devtools/",
+    ],
   },
   {
-    regex: /^resource:\/\/gre\/modules\/devtools\/shared\/apps\//,
-    replacement: "resource://gre/modules/devtools/"
+    regex: /^resource:\/\/devtools\/shared\/apps\//,
+    replacements: [
+      "resource://gre/modules/devtools/shared/apps/",
+      "resource://gre/modules/devtools/",
+    ],
   },
   {
-    regex: /^resource:\/\/gre\/modules\/devtools\/shared\//,
-    replacement: "resource://gre/modules/devtools/"
+    regex: /^resource:\/\/devtools\/shared\//,
+    replacements: [
+      "resource://gre/modules/devtools/shared/",
+      "resource://gre/modules/devtools/",
+    ],
   },
 ];
 
@@ -30,10 +39,18 @@ function devtoolsImport(path) {
     return scopedImport(path);
   } catch (e) {
     // Attempt known renames for 43 and earlier
-    for (let { regex, replacement } of PATH_RENAMES) {
-      path = path.replace(regex, replacement);
+    for (let { regex, replacements } of PATH_RENAMES) {
+      if (!path.match(regex)) {
+        continue;
+      }
+      for (let replacement of replacements) {
+        try {
+          return scopedImport(path.replace(regex, replacement));
+        } catch(e) {
+          // Continue trying other replacements
+        }
+      }
     }
-    return scopedImport(path);
   }
 }
 

--- a/devtools-require.js
+++ b/devtools-require.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const { devtools } =
-  require("./devtools-import")("resource://gre/modules/devtools/shared/Loader.jsm");
+  require("./devtools-import")("resource://devtools/shared/Loader.jsm");
 
 // In Firefox 44 and later, many DevTools modules were relocated.
 // See https://bugzil.la/912121

--- a/fastboot.js
+++ b/fastboot.js
@@ -27,7 +27,7 @@ try {
 Cu.import("resource://gre/modules/osfile.jsm");
 
 let {Devices} =
-  require("./devtools-import")("resource://gre/modules/devtools/shared/apps/Devices.jsm");
+  require("./devtools-import")("resource://devtools/shared/apps/Devices.jsm");
 
 let fastbootTimer = null;
 let fastbootDevices = [];

--- a/main.js
+++ b/main.js
@@ -11,9 +11,9 @@ const events = require("sdk/event/core");
 const { when: unload } = require("sdk/system/unload");
 const system = require("sdk/system");
 const { Devices } =
-  require("./devtools-import")("resource://gre/modules/devtools/shared/apps/Devices.jsm");
+  require("./devtools-import")("resource://devtools/shared/apps/Devices.jsm");
 const { gDevToolsBrowser } =
-  require("./devtools-import")("resource:///modules/devtools/client/framework/gDevTools.jsm");
+  require("./devtools-import")("resource://devtools/client/framework/gDevTools.jsm");
 defineLazyGetter(this, "adb", () => {
   return require("./adb");
 });

--- a/scanner.js
+++ b/scanner.js
@@ -10,7 +10,7 @@ const { when: unload } = require("sdk/system/unload");
 const { ConnectionManager } =
   require("./devtools-require")("devtools/shared/client/connection-manager");
 const { Devices } =
-  require("./devtools-import")("resource://gre/modules/devtools/shared/apps/Devices.jsm");
+  require("./devtools-import")("resource://devtools/shared/apps/Devices.jsm");
 const Runtimes =
   require("./devtools-require")("devtools/client/webide/modules/runtimes");
 


### PR DESCRIPTION
r=ochameau

I've updated our path mapping for all 3 cases:

* Firefox 43 and earlier
* Firefox 44 early cycle (initial file move)
* Firefox 44 late cycle (resource://devtools)