### PR TITLE
to display only device name

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -135,7 +135,7 @@ FirefoxOSRuntime.prototype = Object.create(Runtime.prototype);
 
 Object.defineProperty(FirefoxOSRuntime.prototype, "name", {
   get: function() {
-    return "Firefox OS (" + (this._model || this.device.id) + ")";
+    return this._model || this.device.id;
   }
 });
 


### PR DESCRIPTION
Hello,
The reason of this pull request is that some devices may not be able to use "Firefox OS" brand.
Could you consider this?