### PR TITLE
Bug 1395741 - migrate from sdk-loader to devtools loader;r=ochameau

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -22,6 +22,16 @@ function registerAddonResourceHandler(data) {
   return "resource://" + resourceName + "/";
 }
 
+function getBaseLoader() {
+  try {
+    // >=FF57 use the base-loader from DevTools.
+    return Cu.import("resource://devtools/shared/base-loader.js", {});
+  } catch (e) {
+    // <FF57 use the addon-sdk loader.
+    return Cu.import("resource://gre/modules/commonjs/toolkit/loader.js").Loader;
+  }
+}
+
 let mainModule;
 let loader;
 let unload;
@@ -31,19 +41,14 @@ function install(data, reason) {}
 function startup(data, reason) {
   let uri = registerAddonResourceHandler(data);
 
-  let loaderModule =
-    Cu.import('resource://gre/modules/commonjs/toolkit/loader.js').Loader;
-  let { Loader, Require, Main } = loaderModule;
+  let loaderModule = getBaseLoader();
+  let { Loader, Require } = loaderModule;
   unload = loaderModule.unload;
 
   let loaderOptions = {
     paths: {
       "./": uri,
-      "": "resource://gre/modules/commonjs/"
     },
-    modules: {
-      "toolkit/loader": loaderModule
-    }
   };
 
   /**

--- a/events.js
+++ b/events.js
@@ -6,7 +6,7 @@
  // Firefox with SDK.
  try {
    // <FF57
-   module.exports = require("sdk/event/core");
+   module.exports = require("resource://gre/modules/commonjs/sdk/event/core");
  } catch(e) {
    // >=FF57, after SDK removal
    module.exports = require("./devtools-require")("devtools/shared/event-emitter");

--- a/template-install.rdf
+++ b/template-install.rdf
@@ -13,7 +13,7 @@
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
         <em:minVersion>40.0a1</em:minVersion>
-        <em:maxVersion>44.0a1</em:maxVersion>
+        <em:maxVersion>*</em:maxVersion>
       </Description>
     </em:targetApplication>
 


### PR DESCRIPTION
I have tested this both with the latest central and with an older Nightly that didn't have `resource://devtools/shared/base-loader.js`

In both cases I could see my android runtime and connect to it.