### PR TITLE
Bug 1390265 - Fix a display issue from Aurora to Nightly; r=jryans

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -174,7 +174,7 @@ Object.defineProperty(FirefoxOnAndroidRuntime.prototype, "name", {
         channel = " Beta";
         break;
       case "org.mozilla.fennec_aurora":
-        channel = " Aurora";
+        channel = " Nightly";
         break;
       case "org.mozilla.fennec":
         channel = " Nightly";


### PR DESCRIPTION
Nightly versions from the playstore were incorrectly reported as Aurora
after project dawn (bug 1357351) resulted in the use of
org.mozilla.fennec_aurora for the Nightly channel on the Google Play
Store.

PR fixing https://bugzilla.mozilla.org/show_bug.cgi?id=1390265