### PR TITLE
Bug 1390265 - Add a comment to explain the Aurora package display; r=…

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -174,6 +174,9 @@ Object.defineProperty(FirefoxOnAndroidRuntime.prototype, "name", {
         channel = " Beta";
         break;
       case "org.mozilla.fennec_aurora":
+        // This package name is now the one for Firefox Nightly distributed
+        // through the Google Play Store since "dawn project"
+        // cf. https://bugzilla.mozilla.org/show_bug.cgi?id=1357351#c8
         channel = " Nightly";
         break;
       case "org.mozilla.fennec":


### PR DESCRIPTION
…jryans

Commit 62cfada3190ed5e702c2bd70b4bc30f16be73318 fixed display of Firefox
version for Nightly distributed through the Google Play Store.
However I didn't added the proper comment to help reader understand the
reason behing this. This is fixed here.

Completing for bug https://bugzilla.mozilla.org/show_bug.cgi?id=1390265