### PR TITLE
Support abstract socket for USB connection

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -87,7 +87,12 @@ Runtime.prototype = {
   connect(connection) {
     let port = ConnectionManager.getFreeTCPPort();
     let local = "tcp:" + port;
-    let remote = "localfilesystem:" + this._socketPath;
+    let remote;
+    if (this._socketPath.startsWith("@")) {
+        remote = "localabstract:" + this._socketPath.substring(1);
+    } else {
+        remote = "localfilesystem:" + this._socketPath;
+    }
     return this.device.forwardPort(local, remote).then(() => {
       connection.host = "localhost";
       connection.port = port;


### PR DESCRIPTION
I would like to add abstract socket address support to support Android O.  When target SDK is 26+, adb cannot connect UNIX domain socket due to no permission by new security feature of Android O (https://bugzilla.mozilla.org/show_bug.cgi?id=1462019).  Although Fennec still uses 23 for it, new GeckoView application such as VR Browser and etc will use 26+. 

Abstract socket address can still connect it even if Android O and Chrome uses it.  So we should support it on adbhelper.

If using abstract socket address, /proc/net/address shows "@" prefix like the following.
```
0000000000000000: 00000002 00000000 00010000 0001 01 4075810 @firefox-debugger-socket
```